### PR TITLE
adds show(io::IO, ::EnsembleKalmanInversion)

### DIFF
--- a/src/EnsembleKalmanInversions.jl
+++ b/src/EnsembleKalmanInversions.jl
@@ -64,6 +64,19 @@ mutable struct EnsembleKalmanInversion{I, P, E, M, O, F, S, D}
     dropped_ensemble_members :: D
 end
 
+Base.show(io::IO, eki::EnsembleKalmanInversion) = 
+    print(io, "EnsembleKalmanInversion", '\n',
+              "├── inverse_problem: ", typeof(eki.inverse_problem).name.wrapper, '\n',
+              "├── parameter_distribution: ", typeof(eki.parameter_distribution).name.wrapper, '\n',
+              "├── ensemble_kalman_process: ", typeof(eki.ensemble_kalman_process), '\n',
+              "├── mapped_observations: ", typeof(eki.mapped_observations), '\n',
+              "├── noise_covariance: ", typeof(eki.noise_covariance), '\n',
+              "├── inverting_forward_map: ", typeof(eki.inverting_forward_map).name.wrapper, '\n',
+              "├── iteration: $(eki.iteration)", '\n',
+              "├── iteration_summaries: $(eki.iteration_summaries)", '\n',
+              "└── dropped_ensemble_members: $(eki.dropped_ensemble_members)", '\n'
+              )
+
 construct_noise_covariance(noise_covariance::AbstractMatrix, y) = noise_covariance
 
 function construct_noise_covariance(noise_covariance::Number, y)


### PR DESCRIPTION
This is something. Better than before but feel free to modify!

```julia
julia> eki
EnsembleKalmanInversion
├── inverse_problem: InverseProblem
├── parameter_distribution: EnsembleKalmanProcesses.ParameterDistributionStorage.ParameterDistribution
├── ensemble_kalman_process: EnsembleKalmanProcesses.EnsembleKalmanProcessModule.EnsembleKalmanProcess{Float64, Int64, EnsembleKalmanProcesses.EnsembleKalmanProcessModule.Inversion}
├── mapped_observations: Vector{Float64}
├── noise_covariance: Matrix{Float64}
├── inverting_forward_map: OceanTurbulenceParameterEstimation.EnsembleKalmanInversions.var"#G#11"
├── iteration: 0
├── iteration_summaries: Any[]
└── dropped_ensemble_members: Set{Any}()
```

Closes #34